### PR TITLE
Fixed Discord link in get help docs

### DIFF
--- a/docs/2.developers/4.user-guide/120.development/30.get-help.md
+++ b/docs/2.developers/4.user-guide/120.development/30.get-help.md
@@ -72,7 +72,7 @@ We're here to help you make the most of your experience. Whether you're a beginn
         icon: 'uil:discord'
         button:
             text: 'Join us on Discord'
-            href: 'https://github.com/pathwaycom/'
+            href: 'https://discord.com/invite/pathway'
         ---
         #title
         Connect with Us on Discord


### PR DESCRIPTION
Before this commit, the "Connect with Us on Discord" link was leading to the GitHub page of Pathway rather than the Discord invite. I have corrected the URL to the Discord invite link.

### Introduction
To contribute code to the Pathway project, start by discussing your proposed changes on Discord or by filing an issue. 
Once approved, follow the fork + pull request model against the main branch, ensuring you've signed the contributor license agreement.

### Context
Before this commit, the "Connect with Us on Discord" link was leading to the GitHub page of Pathway rather than the Discord invite. I have corrected the URL to the Discord invite link.

### How has this been tested?
Markdown update only, following the previous syntax.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!---
### Related issue(s):
1. 
2.
3.
-->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [x] I described the modification in the CHANGELOG.md file.