### PR TITLE
fix: metadata is none or not

### DIFF
--- a/python/pathway/xpacks/llm/vector_store.py
+++ b/python/pathway/xpacks/llm/vector_store.py
@@ -231,7 +231,10 @@ pw.io.fs.read('./sample_docs', format='binary', mode='static', with_metadata=Tru
         @pw.udf
         def parse_doc(data: bytes, metadata) -> list[pw.Json]:
             rets = self.parser(data)
-            metadata = metadata.value
+            if metadata is None:
+                metadata = {}
+            else:
+                metadata = metadata.value
             return [dict(text=ret[0], metadata={**metadata, **ret[1]}) for ret in rets]  # type: ignore
 
         parsed_docs = docs.select(data=parse_doc(docs.data, docs._metadata)).flatten(


### PR DESCRIPTION
### Introduction
To contribute code to the Pathway project, start by discussing your proposed changes on Discord or by filing an issue. 
Once approved, follow the fork + pull request model against the main branch, ensuring you've signed the contributor license agreement.

### Context
This change addresses a potential issue where the metadata variable might be None. In such cases, attempting to access metadata.value would raise an AttributeError. This fix ensures that we handle the None case gracefully by assigning an empty dictionary, preventing potential runtime errors.

### How has this been tested?
Indexing your contents, then stopping server and reindexing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.