### PR TITLE
Introducing Pathway Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
         <img src="https://img.shields.io/badge/pathway-0077B5?style=social&logo=linkedin" alt="follow on LinkedIn"></a>
       <a href="https://github.com/dylanhogg/awesome-python/blob/main/README.md">
       <img src="https://awesome.re/badge.svg" alt="Awesome Python"></a>
+      <a href="https://gurubase.io/g/pathway">
+      <img src="https://img.shields.io/badge/Gurubase-Ask%20Pathway%20Guru-006BFF" alt="Pathway Guru"></a>
     <br>
     <a href="#getting-started">Getting Started</a> |
     <a href="#deployment">Deployment</a> |


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Pathway Guru](https://gurubase.io/g/pathway) to Gurubase. Pathway Guru uses the data from this repo and data from the [docs](https://pathway.com/developers/user-guide/introduction/welcome/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Pathway Guru" badge, which highlights that Pathway now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Pathway Guru in Gurubase, just let me know that's totally fine.