### PR TITLE
Fix: Mitigate DoS vulnerability by handling deeply nested JSONs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,8 @@ schema_registry_converter = { version = "4.4.0", features = ["blocking", "json"]
 scopeguard = "1.2.0"
 send_wrapper = "0.6.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["unbounded_depth"] }
+serde_stacker = "0.1"
 serde_with = "3.12.0"
 smallvec = { version = "1.15.0", features = ["union", "const_generics"] }
 syn = { version = "2.0.101", features = ["default", "full", "visit", "visit-mut"] } # Hack to keep features unified between normal and build deps

--- a/src/connectors/data_lake/mod.rs
+++ b/src/connectors/data_lake/mod.rs
@@ -1,4 +1,5 @@
 use log::error;
+use crate::connectors::utils::from_str_safe;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -137,7 +138,7 @@ pub fn parquet_value_into_pathway_value(
         (ParquetValue::Double(f), Type::Float | Type::Any) => Some(Value::Float((*f).into())),
         (ParquetValue::Str(s), Type::String | Type::Any) => Some(Value::String(s.into())),
         (ParquetValue::Str(s), Type::Pointer) => parse_pathway_pointer(s).ok(),
-        (ParquetValue::Str(s), Type::Json) => serde_json::from_str::<serde_json::Value>(s)
+        (ParquetValue::Str(s), Type::Json) => from_str_safe::<serde_json::Value>(s)
             .ok()
             .map(Value::from),
         (ParquetValue::TimestampMicros(us), Type::DateTimeNaive | Type::Any) => Some(Value::from(
@@ -540,7 +541,7 @@ fn convert_arrow_string_array<OffsetType: OffsetSizeTrait>(
         .map(|v| match v {
             Some(v) => match expected_type {
                 Type::String | Type::Any => Ok(Value::String(v.into())),
-                Type::Json => serde_json::from_str::<serde_json::Value>(v)
+                Type::Json => from_str_safe::<serde_json::Value>(v)
                     .map(Value::from)
                     .map_err(|_| {
                         Box::new(conversion_error(

--- a/src/connectors/data_storage.rs
+++ b/src/connectors/data_storage.rs
@@ -1,3 +1,4 @@
+use crate::connectors::utils::from_str_safe;
 // Copyright © 2024 Pathway
 
 use base64::Engine;
@@ -1807,7 +1808,7 @@ impl SqliteReader {
             (Type::Json, SqliteValue::Text(val)) => from_utf8(val)
                 .ok()
                 .and_then(|parsed_string| {
-                    serde_json::from_str::<serde_json::Value>(parsed_string).ok()
+                    from_str_safe::<serde_json::Value>(parsed_string).ok()
                 })
                 .map(Value::from),
             (Type::Bytes | Type::Any, SqliteValue::Blob(val)) => Some(Value::Bytes(val.into())),

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -19,6 +19,7 @@ use timely::dataflow::operators::probe::Handle;
 pub mod adaptors;
 pub mod aws;
 pub mod backlog;
+pub mod utils;
 pub mod data_format;
 pub mod data_lake;
 pub mod data_storage;

--- a/src/connectors/utils.rs
+++ b/src/connectors/utils.rs
@@ -1,0 +1,11 @@
+use serde_json::Value as JsonValue;
+
+pub fn from_str_safe<'a, T>(s: &'a str) -> serde_json::Result<T>
+where
+    T: serde::de::Deserialize<'a>,
+{
+    let mut deserializer = serde_json::Deserializer::from_str(s);
+    deserializer.disable_recursion_limit();
+    let mut deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+    T::deserialize(&mut deserializer).map_err(|e| e.into_inner())
+}


### PR DESCRIPTION
This commit introduces a fix for a potential denial-of-service (DoS) vulnerability that could be triggered by providing a deeply nested JSON payload. The `serde_json::from_str` function, which was used for parsing JSON, is susceptible to stack overflows when dealing with such payloads.

To mitigate this, the `serde_stacker` crate has been introduced. This crate provides a deserializer that uses a dynamically growing stack, thus preventing stack overflows when parsing deeply nested JSON structures.

A helper function, `from_str_safe`, has been created to encapsulate the usage of `serde_stacker`. All instances of `serde_json::from_str` have been replaced with this new safe function.