### PR TITLE
fix metadata parsing exception in document_store.py

### DIFF
--- a/python/pathway/xpacks/llm/document_store.py
+++ b/python/pathway/xpacks/llm/document_store.py
@@ -34,9 +34,8 @@ if TYPE_CHECKING:
 def _get_jmespath_filter(metadata_filter: str, filepath_globpattern: str) -> str | None:
     ret_parts = []
     if metadata_filter:
-        metadata_filter = (
-            metadata_filter.replace("'", r"\'").replace("`", "'").replace('"', "")
-        )
+        # Remove problematic quote escaping that causes parse errors
+        metadata_filter = metadata_filter.replace("`", "'")
         ret_parts.append(f"({metadata_filter})")
     if filepath_globpattern:
         ret_parts.append(f"globmatch('{filepath_globpattern}', path)")


### PR DESCRIPTION
# Bug Report: JMESPath Filter Parse Error with Escaped Single Quotes
Problem Description
The *_get_jmespath_filter* function in [document_store.py] causes a parsing error when processing metadata filters that contain single quotes. The function incorrectly escapes single quotes by adding backslashes, which creates invalid JMESPath syntax.

## Error Message:
pathway.engine.EngineError: Parse error: Invalid character: \ (line 0, column 11)
(category==\'food\')

## Root Cause: 
In line 38 of [document_store.py], the function performs this transformation:
```
metadata_filter.replace("'", r"\'").replace("`", "'").replace('"', "")
```

When a metadata filter like category=='food' is processed, it becomes category==\'food\', which contains escaped single quotes that are invalid in JMESPath syntax.