### PR TITLE
security: bump aiohttp to 3.10.11 to fix request smuggling vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "aiohttp >= 3.8.4",
+    "aiohttp >= 3.10.11",
     "click >= 8.1",
     "geopy >= 2.4.0",
     "h3 >= 4",


### PR DESCRIPTION
Hi team,

I was reviewing the project's dependencies and noticed that `aiohttp` is currently pinned to `>= 3.8.4`. 

Versions of `aiohttp` prior to 3.10.11 are vulnerable to several security issues, most notably **HTTP Request Smuggling** (CVE-2024-52304). Given that Pathway is a streaming data framework that often interacts with external network services, ensuring a secure HTTP client is quite important.

I've bumped the requirement to `>= 3.10.11` to mitigate these risks. This should be a safe, non-breaking update for the current codebase.

Best,
Rin