### PR TITLE
docs: fix incorrect return type in add_example docstring

### DIFF
--- a/python/pathway/io/http/_server.py
+++ b/python/pathway/io/http/_server.py
@@ -111,7 +111,7 @@ class EndpointExamples:
                 schema to their values in the example.
 
         Returns:
-            None
+            EndpointExamples: The current instance, allowing method chaining.
         """
         if id in self.examples_by_id:
             raise ValueError(f"Duplicate example id: {id}")


### PR DESCRIPTION
## Summary
- Fixes incorrect docstring in `EndpointExamples.add_example()` method

## Details
The docstring for `add_example()` stated it returns `None`, but the method actually returns `self` to enable method chaining. Updated the return documentation to accurately reflect this behavior.

## Test plan
- [x] Verified the docstring matches the actual return value
- [x] No functionality changes, documentation only