### PR TITLE
docs: fix duplicate word typos in docstrings

### DIFF
--- a/python/pathway/io/mqtt/__init__.py
+++ b/python/pathway/io/mqtt/__init__.py
@@ -264,7 +264,7 @@ def write(
     ...     value=table.owner,
     ... )
 
-    Finally, if you'd like the topic to be dynamic and depend on the the owner of the pet,
+    Finally, if you'd like the topic to be dynamic and depend on the owner of the pet,
     you can specify this column definition as the topic:
 
     >>> pw.io.mqtt.write(

--- a/python/pathway/xpacks/llm/document_store.py
+++ b/python/pathway/xpacks/llm/document_store.py
@@ -727,7 +727,7 @@ class DocumentStoreClient:
         return_status: bool = False,
     ):
         """
-        Fetch information on documents in the the vector store.
+        Fetch information on documents in the vector store.
 
         Args:
             metadata_filter: optional string representing the metadata filtering query


### PR DESCRIPTION
## Summary
- Fixes duplicate word typos ('the the' -> 'the') in docstrings

## Files Changed
- `python/pathway/xpacks/llm/document_store.py`: Line 730
- `python/pathway/io/mqtt/__init__.py`: Line 267

## Test plan
- [x] Documentation-only changes, no functionality affected