### PR TITLE
docs: fix duplicate 'To to' typo in docstring

### DIFF
--- a/python/pathway/stdlib/indexing/data_index.py
+++ b/python/pathway/stdlib/indexing/data_index.py
@@ -433,7 +433,7 @@ class DataIndex:
         when the IDs match (exactly one row per match plus one row per query with no matches).
 
         The index answers according to the current state of the data structure and does not
-        revisit old answers. To to work properly, the ``inner_index`` has to be an instance
+        revisit old answers. To work properly, the ``inner_index`` has to be an instance
         of ``InnerIndex`` supporting ``query`` (all predefined indices support it, this is an
         information for third party extensions).
 


### PR DESCRIPTION
## Summary
- Fixes duplicate word typo in docstring

## Files Changed
- `python/pathway/stdlib/indexing/data_index.py`: "To to" -> "To" (line 436)

## Test plan
- [x] Documentation-only change, no functionality affected