### PR TITLE
docs: fix duplicate 'with with' typo in docstring

### DIFF
--- a/python/pathway/io/deltalake/__init__.py
+++ b/python/pathway/io/deltalake/__init__.py
@@ -392,7 +392,7 @@ def read(
     >>> lake_path = getfixture("tmp_path") / "local-lake"  # NODOCS
     >>> pw.io.deltalake.write(output_table, lake_path)
 
-    Now the producer code can be run with with a simple ``pw.run``:
+    Now the producer code can be run with a simple ``pw.run``:
 
     >>> pw.run(monitoring_level=pw.MonitoringLevel.NONE)
 


### PR DESCRIPTION
## Summary
- Fixes duplicate word typo in docstring

## Files Changed
- `python/pathway/io/deltalake/__init__.py`: "with with" -> "with" (line 395)

## Test plan
- [x] Documentation-only change, no functionality affected