### PR TITLE
Allow setting query transformers in BaseRAGQuestionAnswerer

### DIFF
--- a/python/pathway/xpacks/llm/question_answering.py
+++ b/python/pathway/xpacks/llm/question_answering.py
@@ -644,8 +644,15 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
 
         if self.query_transformer_prompt is not None:
             pw_ai_queries = pw_ai_queries.with_columns(
-                prompt=self.query_transformer_prompt(pw.this.prompt)
+                rewrite_prompt=self.query_transformer_prompt(pw.this.prompt)
             )
+            pw_ai_queries += pw_ai_queries.select(
+                prompt=self.llm(
+                    llms.prompt_chat_single_qa(pw.this.rewrite_prompt),
+                    model=pw.this.model,
+                )
+            )
+            pw_ai_queries = pw_ai_queries.await_futures()
 
         pw_ai_results = pw_ai_queries + self.indexer.retrieve_query(
             pw_ai_queries.select(


### PR DESCRIPTION
Summary
Added a new optional parameter query_transformer_prompt: pw.UDF | None to BaseRAGQuestionAnswerer (and AdaptiveRAGQuestionAnswerer) to enable query rewriting/normalization before retrieval and prompt construction.
What changed
BaseRAGQuestionAnswerer.__init__: accepts and stores query_transformer_prompt.
BaseRAGQuestionAnswerer.answer_query: if provided, applies query_transformer_prompt to prompt before calling retriever and before generating the RAG prompt.
AdaptiveRAGQuestionAnswerer.__init__: accepts and forwards query_transformer_prompt.
Updated docstrings to document the new parameter.
Why
Enables custom query transformers (rewrite/expand/normalize) without changing server schemas or external request formats.