### PR TITLE
Use list-based arguments in subprocess calls for better robustness

### DIFF
--- a/python/pathway/cli.py
+++ b/python/pathway/cli.py
@@ -76,9 +76,8 @@ def spawn_program(
                 os.fspath(requirements_path),
             ]
             pip_handle = subprocess.run(
-                " ".join(command),
+                command,
                 stderr=subprocess.STDOUT,
-                shell=True,
             )
             if pip_handle.returncode != 0:
                 process_stdout = pip_handle.stdout.decode("utf-8")

--- a/python/pathway/third_party/airbyte_serverless/executable_runner.py
+++ b/python/pathway/third_party/airbyte_serverless/executable_runner.py
@@ -7,6 +7,7 @@ import copy
 import json
 import os
 import re
+import shlex
 import subprocess
 import tempfile
 import zlib
@@ -207,30 +208,34 @@ class ExecutableAirbyteSource(AbstractAirbyteSource):
 
     def _run(self, action, state=None):
         assert self.executable, "`executable` attribute should be set"
-        command = f"{self.executable} {action}"
+
+        if isinstance(self.executable, (str, os.PathLike)):
+            command = shlex.split(os.fspath(self.executable)) + [action]
+        else:
+            command = [os.fspath(self.executable), action]
 
         def add_argument(name, value):
             with open(f"{self.temp_dir}/{name}.json", "w", encoding="utf-8") as file:
                 json.dump(value, file)
-            return f" --{name} {self.temp_dir_for_executable}/{name}.json"
+            return [f"--{name}", f"{self.temp_dir_for_executable}/{name}.json"]
 
         needs_config = action != "spec"
         if needs_config:
             assert self.config, "config attribute is not defined"
-            command += add_argument("config", self.config)
+            command.extend(add_argument("config", self.config))
 
         needs_configured_catalog = action == "read"
         if needs_configured_catalog:
-            command += add_argument("catalog", self.configured_catalog)
+            command.extend(add_argument("catalog", self.configured_catalog))
 
         if state:
-            command += add_argument("state", state)
+            command.extend(add_argument("state", state))
 
         process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True,
+            shell=False,
             env=self.env_vars,
         )
         if process.stdout is not None:

--- a/python/pathway/third_party/airbyte_serverless/sources.py
+++ b/python/pathway/third_party/airbyte_serverless/sources.py
@@ -109,7 +109,7 @@ class DockerAirbyteSource(ExecutableAirbyteSource):
         )
         self.executable = (
             f"docker run --rm -i --volume {self.temp_dir}:{self.temp_dir_for_executable} "
-            f"{prepared_env_vars} {self.docker_image}"
+            f"{prepared_env_vars} {shlex.quote(self.docker_image)}"
         )
 
     @property
@@ -155,9 +155,8 @@ class VenvAirbyteSource(ExecutableAirbyteSource):
         pip_path = os.fspath(self._venv_path / "bin" / "pip")
         for n_attempt in range(MAX_PIP_INSTALL_ATTEMPTS):
             process = subprocess.run(
-                f"{pip_path} install airbyte-{connector}",
+                [pip_path, "install", f"airbyte-{connector}"],
                 stderr=subprocess.STDOUT,
-                shell=True,
             )
             if process.returncode != 0:
                 result_stdout = process.stdout.decode("utf-8") if process.stdout else ""


### PR DESCRIPTION
### Introduction
I noticed some potential issues in how subprocesses are handled and decided to refactor them for better robustness.

### Context
The current implementation uses `shell=True` and string interpolation in several places (CLI, Airbyte connectors), which can be problematic if user-supplied strings contain shell metacharacters. Switching to list-based arguments and `shell=False` is a more robust approach that avoids manual shell quoting.

### How has this been tested?
I've verified the syntax with `py_compile`. The functional logic remains identical as this is a refactoring of the execution layer.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.