### PR TITLE
Fix docs: remove empty markdown link

### DIFF
--- a/docs/2.developers/7.templates/ETL/140.kafka-etl.md
+++ b/docs/2.developers/7.templates/ETL/140.kafka-etl.md
@@ -362,5 +362,5 @@ You are now ready to do Kafka ETL with Pathway.
 Your setup probably differs slightly, and your ETL pipeline may require different operators.
 Pathway offers many [connectors](/developers/user-guide/connect/supported-data-sources) for extracting and loading the data from and to various sources.
 In addition to standard [table operations](/developers/user-guide/data-transformation/table-operations), Pathway also supports temporal operations such as [ASOF joins](/developers/user-guide/temporal-data/asof-join) and [interval joins](/developers/user-guide/temporal-data/interval-join).
-<!--You can also define your own [user-defined functions](). WAITING FOR ARTICLE-->
+<!--You can also define your own user-defined functions. WAITING FOR ARTICLE-->
 Don't hesitate to take a look at [Pathway documentation](/developers/user-guide/introduction/welcome) and reach out to us on [Discord](https://discord.com/invite/pathway) if you don't find the operator you are looking for.


### PR DESCRIPTION
This PR removes an empty markdown link for user-defined functions in the Kafka ETL documentation. The link syntax was present but the URL was empty, as the referenced article has not been written yet (noted by the WAITING FOR ARTICLE comment).