### PR TITLE
Add query transformer prompt to BaseRAGQuestionAnswerer

### DIFF
--- a/python/pathway/xpacks/llm/question_answering.py
+++ b/python/pathway/xpacks/llm/question_answering.py
@@ -146,6 +146,21 @@ def _get_context_processor_udf(
         )
 
 
+def _get_query_transformer_prompt_udf(
+    query_transformer_prompt: Callable[[str], str] | pw.UDF | None,
+) -> pw.UDF | None:
+    if query_transformer_prompt is None:
+        return None
+    if isinstance(query_transformer_prompt, pw.UDF):
+        return query_transformer_prompt
+    if callable(query_transformer_prompt):
+        return pw.udf(query_transformer_prompt)
+    raise ValueError(
+        "Query transformer prompt must be type of one of the following: "
+        "Callable[[str], str] | ~pw.UDF | None"
+    )
+
+
 def _query_chat(
     chat: BaseChat,
     t: Table,
@@ -456,6 +471,11 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
             Either string template, callable or a pw.udf function is expected.
             Defaults to ``pathway.xpacks.llm.prompts.prompt_qa``.
             String template needs to have ``context`` and ``query`` placeholders in curly brackets ``{}``.
+        query_transformer_prompt: Prompt for transforming the user query before
+            retrieval. If set, it must be a callable or UDF that accepts the user
+            query and returns a prompt for ``llm``. The transformed LLM response
+            is used only for retrieval; the answer prompt still receives the
+            original user query. Defaults to ``None``.
         context_processor: Utility for representing the fetched documents to the LLM. Callable, UDF or ``BaseContextProcessor`` is expected.
             Defaults to ``SimpleContextProcessor`` that keeps the 'path' metadata and joins the documents with double new lines.
         summarize_template: Template for text summarization. Defaults to ``pathway.xpacks.llm.prompts.prompt_summarize``.
@@ -516,6 +536,7 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
         *,
         default_llm_name: str | None = None,
         prompt_template: str | Callable[[str, str], str] | pw.UDF = prompts.prompt_qa,
+        query_transformer_prompt: Callable[[str], str] | pw.UDF | None = None,
         context_processor: (
             BaseContextProcessor | Callable[[list[dict] | list[Doc]], str] | pw.UDF
         ) = SimpleContextProcessor(),
@@ -535,6 +556,9 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
         self._init_schemas(default_llm_name)
 
         self.prompt_udf = _get_RAG_prompt_udf(prompt_template)
+        self.query_transformer_prompt_udf = _get_query_transformer_prompt_udf(
+            query_transformer_prompt
+        )
 
         if isinstance(context_processor, BaseContextProcessor):
             self.docs_to_context_transformer = context_processor.as_udf()
@@ -638,11 +662,28 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
     def answer_query(self, pw_ai_queries: pw.Table) -> pw.Table:
         """Answer a question based on the available information."""
 
-        pw_ai_results = pw_ai_queries + self.indexer.retrieve_query(
-            pw_ai_queries.select(
+        pw_ai_results = pw_ai_queries
+        if self.query_transformer_prompt_udf is not None:
+            pw_ai_results += pw_ai_results.select(
+                query_transformer_prompt=self.query_transformer_prompt_udf(
+                    pw.this.prompt
+                )
+            )
+            pw_ai_results += pw_ai_results.select(
+                search_query=self.llm(
+                    llms.prompt_chat_single_qa(pw.this.query_transformer_prompt),
+                    model=pw.this.model,
+                )
+            )
+            pw_ai_results = pw_ai_results.await_futures()
+        else:
+            pw_ai_results += pw_ai_results.select(search_query=pw.this.prompt)
+
+        pw_ai_results += self.indexer.retrieve_query(
+            pw_ai_results.select(
                 metadata_filter=pw.this.filters,
                 filepath_globpattern=pw.cast(str | None, None),
-                query=pw.this.prompt,
+                query=pw.this.search_query,
                 k=self.search_topk,
             )
         ).select(

--- a/python/pathway/xpacks/llm/tests/test_rag.py
+++ b/python/pathway/xpacks/llm/tests/test_rag.py
@@ -39,6 +39,27 @@ def _summarize_template(docs: list[str]) -> str:
     return f"summarize,{','.join(docs)}"
 
 
+class QueryTransformMockChat(llms.BaseChat):
+    def _accepts_call_arg(self, arg_name: str) -> bool:
+        return False
+
+    async def __wrapped__(self, messages: list[dict] | pw.Json, model: str) -> str:
+        content = messages[0]["content"].as_str()
+        if content.startswith("rewrite:"):
+            return content.removeprefix("rewrite:")
+        return model + "," + content
+
+
+@pw.udf
+def _query_transformer_prompt(query: str) -> str:
+    return "rewrite:bar"
+
+
+@pw.udf
+def _query_aware_prompt_template(context: str, query: str) -> str:
+    return f"{query}|{context}"
+
+
 def test_base_rag():
     schema = pw.schema_from_types(data=bytes, _metadata=dict)
     input = pw.debug.table_from_rows(
@@ -130,6 +151,61 @@ def test_rag_app_set_udf_prompt():
     assert isinstance(rag_app.prompt_udf, pw.UDF)
 
     assert _unwrap_udf(rag_app.prompt_udf)(query=" ", context=" ")
+
+
+def test_rag_app_set_query_transformer_prompt():
+    def query_transformer_prompt(query: str) -> str:
+        return f"rewrite:{query}"
+
+    rag_app = create_rag_app(query_transformer_prompt=query_transformer_prompt)
+
+    assert isinstance(rag_app.query_transformer_prompt_udf, pw.UDF)
+
+    assert _unwrap_udf(rag_app.query_transformer_prompt_udf)("foo") == "rewrite:foo"
+
+
+def test_base_rag_uses_transformed_query_for_retrieval():
+    schema = pw.schema_from_types(data=bytes, _metadata=dict)
+    input = pw.debug.table_from_rows(
+        schema=schema, rows=[("foo", {}), ("bar", {}), ("baz", {})]
+    )
+
+    vector_server = VectorStoreServer(
+        input,
+        embedder=fake_embeddings_model,
+    )
+
+    rag = BaseRAGQuestionAnswerer(
+        QueryTransformMockChat(),
+        vector_server,
+        prompt_template=_query_aware_prompt_template,
+        query_transformer_prompt=_query_transformer_prompt,
+        summarize_template=_summarize_template,
+        search_topk=1,
+    )
+
+    answer_queries = pw.debug.table_from_rows(
+        schema=rag.AnswerQuerySchema,
+        rows=[
+            ("foo", None, "gpt3.5", False),
+        ],
+    )
+
+    answer_output = rag.answer_query(answer_queries)
+
+    casted_table = answer_output.select(
+        result=pw.apply_with_type(lambda x: x.value, str, pw.this.result["response"])
+    )
+
+    assert_table_equality(
+        casted_table,
+        pw.debug.table_from_markdown(
+            """
+            result
+            gpt3.5,foo|bar
+            """
+        ),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #67.

This adds an optional `query_transformer_prompt` parameter to `BaseRAGQuestionAnswerer`. When it is set, the LLM transforms the user query before retrieval while the original query is still used for the final RAG prompt.

The tests cover callable setup and transformed-query retrieval behavior.

Tests:
- `git diff --check`
- `python -m py_compile python/pathway/xpacks/llm/question_answering.py python/pathway/xpacks/llm/tests/test_rag.py`
- `black --check python/pathway/xpacks/llm/question_answering.py python/pathway/xpacks/llm/tests/test_rag.py`

Not run: targeted pytest, because this checkout requires Pathway's Rust extension build before imports succeed.
