### PR TITLE
Allow RAG query transformation before retrieval

### DIFF
--- a/python/pathway/xpacks/llm/question_answering.py
+++ b/python/pathway/xpacks/llm/question_answering.py
@@ -146,6 +146,20 @@ def _get_context_processor_udf(
         )
 
 
+def _get_query_transformer_udf(
+    query_transformer: Callable[[str], str] | pw.UDF | None,
+) -> pw.UDF:
+    if query_transformer is None:
+        return pw.udf(lambda query: query)
+    if isinstance(query_transformer, pw.UDF):
+        return query_transformer
+    if callable(query_transformer):
+        return pw.udf(query_transformer)
+    raise ValueError(
+        f"Query transformer is not of expected type. Got: {type(query_transformer)}."
+    )
+
+
 def _query_chat(
     chat: BaseChat,
     t: Table,
@@ -460,6 +474,7 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
             Defaults to ``SimpleContextProcessor`` that keeps the 'path' metadata and joins the documents with double new lines.
         summarize_template: Template for text summarization. Defaults to ``pathway.xpacks.llm.prompts.prompt_summarize``.
         search_topk: Top k parameter for the retrieval. Adjusts number of chunks in the context.
+        query_transformer: Optional callable or UDF applied to the user query before retrieval.
         rerank_topk: Number of top-scoring documents to retain after reranking, when a reranker is provided.
             If ``None``, reranking is disabled. Defaults to ``None``.
 
@@ -521,6 +536,7 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
         ) = SimpleContextProcessor(),
         summarize_template: pw.UDF = prompts.prompt_summarize,
         search_topk: int = 6,
+        query_transformer: Callable[[str], str] | pw.UDF | None = None,
         reranker: pw.UDF | None = None,
         rerank_topk: int | None = None,
     ) -> None:
@@ -535,6 +551,7 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
         self._init_schemas(default_llm_name)
 
         self.prompt_udf = _get_RAG_prompt_udf(prompt_template)
+        self.query_transformer = _get_query_transformer_udf(query_transformer)
 
         if isinstance(context_processor, BaseContextProcessor):
             self.docs_to_context_transformer = context_processor.as_udf()
@@ -638,11 +655,15 @@ class BaseRAGQuestionAnswerer(SummaryQuestionAnswerer):
     def answer_query(self, pw_ai_queries: pw.Table) -> pw.Table:
         """Answer a question based on the available information."""
 
+        pw_ai_queries += pw_ai_queries.select(
+            search_query=self.query_transformer(pw.this.prompt)
+        )
+
         pw_ai_results = pw_ai_queries + self.indexer.retrieve_query(
             pw_ai_queries.select(
                 metadata_filter=pw.this.filters,
                 filepath_globpattern=pw.cast(str | None, None),
-                query=pw.this.prompt,
+                query=pw.this.search_query,
                 k=self.search_topk,
             )
         ).select(

--- a/python/pathway/xpacks/llm/tests/test_rag.py
+++ b/python/pathway/xpacks/llm/tests/test_rag.py
@@ -99,6 +99,49 @@ def test_base_rag():
     )
 
 
+def test_base_rag_query_transformer_is_used_for_retrieval():
+    schema = pw.schema_from_types(data=bytes, _metadata=dict)
+    input = pw.debug.table_from_rows(
+        schema=schema, rows=[("foo", {}), ("bar", {}), ("baz", {})]
+    )
+
+    vector_server = VectorStoreServer(
+        input,
+        embedder=fake_embeddings_model,
+    )
+
+    rag = BaseRAGQuestionAnswerer(
+        IdentityMockChat(),
+        vector_server,
+        prompt_template=_prompt_template,
+        query_transformer=lambda query: "bar" if query == "foo" else query,
+        search_topk=1,
+    )
+
+    answer_queries = pw.debug.table_from_rows(
+        schema=rag.AnswerQuerySchema,
+        rows=[
+            ("foo", None, "gpt3.5", False),
+        ],
+    )
+
+    answer_output = rag.answer_query(answer_queries)
+
+    casted_table = answer_output.select(
+        result=pw.apply_with_type(lambda x: x.value, str, pw.this.result["response"])
+    )
+
+    assert_table_equality(
+        casted_table,
+        pw.debug.table_from_markdown(
+            """
+            result
+            gpt3.5,bar
+            """
+        ),
+    )
+
+
 def test_rag_app_set_prompt():
     prompt_template = "Answer the question. Context: {context}\nQuestion: {query}"
 
@@ -130,6 +173,26 @@ def test_rag_app_set_udf_prompt():
     assert isinstance(rag_app.prompt_udf, pw.UDF)
 
     assert _unwrap_udf(rag_app.prompt_udf)(query=" ", context=" ")
+
+
+def test_rag_app_set_callable_query_transformer():
+    def query_transformer(query: str) -> str:
+        return f"search {query}"
+
+    rag_app = create_rag_app(query_transformer=query_transformer)
+
+    assert isinstance(rag_app.query_transformer, pw.UDF)
+    assert _unwrap_udf(rag_app.query_transformer)("question") == "search question"
+
+
+def test_rag_app_set_udf_query_transformer():
+    @pw.udf
+    def query_transformer(query: str) -> str:
+        return f"search {query}"
+
+    rag_app = create_rag_app(query_transformer=query_transformer)
+
+    assert rag_app.query_transformer is query_transformer
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds an optional `query_transformer` argument to `BaseRAGQuestionAnswerer` so users can rewrite or expand the user query before retrieval while preserving the original prompt for answer generation.

This addresses #67 and keeps the default behavior unchanged by using an identity transformer when none is provided.

## Tests

- `python -m ruff check python/pathway/xpacks/llm/question_answering.py python/pathway/xpacks/llm/tests/test_rag.py`
- `git diff --check`

I also tried `python -m pytest python/pathway/xpacks/llm/tests/test_rag.py -q`, but this local machine does not have `cargo`; the test run stopped while importing/building the Pathway engine before reaching these tests.