### PR TITLE
fix(test): correct async context manager mocking for bedrock routing

### DIFF
--- a/python/pathway/xpacks/llm/tests/test_llms.py
+++ b/python/pathway/xpacks/llm/tests/test_llms.py
@@ -201,7 +201,7 @@ def test_bedrock_call_args(model_id, call_arg):
 
 @pytest.mark.asyncio
 async def test_bedrock_dynamic_args_routing():
-    from unittest.mock import AsyncMock, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     llm = llms.BedrockChat(model_id="anthropic.claude-3", region_name="us-east-1")
 
@@ -210,8 +210,13 @@ async def test_bedrock_dynamic_args_routing():
         return_value={"output": {"message": {"content": [{"text": "mocked"}]}}}
     )
 
-    mock_session = AsyncMock()
-    mock_session.client.return_value.__aenter__.return_value = mock_client
+    # Explicit async context manager returned by session.client(...)
+    mock_client_cm = AsyncMock()
+    mock_client_cm.__aenter__.return_value = mock_client
+    mock_client_cm.__aexit__.return_value = None
+
+    mock_session = MagicMock()
+    mock_session.client.return_value = mock_client_cm
 
     with patch.object(llm, "_session", mock_session):
         await llm.__wrapped__(


### PR DESCRIPTION
### Context
This PR resolves a persistent CI failure (`AttributeError: __aenter__`) in the `test_bedrock_dynamic_args_routing` test suite.

The test previously mocked the Bedrock client session using standard `AsyncMock` behavior, which can be unstable when resolving async context managers across different Python/Pytest environments. Because the `BedrockChat` production code evaluates `async with self._session.client("bedrock-runtime") as client:`, the mocked client must implement strict asynchronous context manager protocols. This PR explicitly constructs and injects a deterministic async context manager (`__aenter__` and `__aexit__`) to guarantee stable test execution.

### How has this been tested?
- **Unit Testing**: Executed local test suites against `python/pathway/xpacks/llm/tests/test_llms.py` to confirm the manual `MagicMock` correctly satisfies the `async with` context evaluation without raising `AttributeError` exceptions.
- **Linting**: Verified full compliance with the repository's formatting pipelines via `black` and `flake8`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. Resolves CI instability introduced by #248 

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation,
- [ ] I described the modification in the CHANGELOG.md file.