### PR TITLE
Optimize CI caching and metrics flush

### DIFF
--- a/.github/workflows/package_test.yml
+++ b/.github/workflows/package_test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v6
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: License files
         run: |
           rm -f LICENSE_*-LICENSE-*

--- a/src/engine/telemetry/exporter.rs
+++ b/src/engine/telemetry/exporter.rs
@@ -171,9 +171,9 @@ impl SqliteExporter {
     }
 
     fn flush_buffer(&self) -> Result<()> {
-        let samples: Vec<_> = {
+        let samples = {
             let mut buf = self.buf.lock().unwrap();
-            buf.drain(..).collect()
+            std::mem::take(&mut *buf)
         };
 
         if samples.is_empty() {


### PR DESCRIPTION
### Context

This change reduces repeated CI build time and removes an avoidable allocation in a hot telemetry flush path.

* The package test workflow now uses Rust caching so unchanged dependencies and build artifacts can be reused across runs.
* The SQLite metrics exporter now uses `std::mem::take` when flushing the buffered samples, which avoids draining into a newly allocated vector.

### How this change came about

I reviewed the package test workflow and the SQLite telemetry exporter, then made two focused changes:

1. Added Rust cache to `.github/workflows/package_test.yml` to reduce repeated build work in CI.
2. Replaced `drain(..).collect()` with `std::mem::take` in `src/engine/telemetry/exporter.rs` to avoid an extra allocation while flushing buffered telemetry.

I made the edits directly in the repository and kept the scope limited to the two files above.

### How has this been tested?

I verified the change by code inspection. No additional runtime test was run in this session.

### Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature or improvement (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation-only change

### Checklist:

* [x] I have read [[CONTRIBUTING.md](https://github.com/pathwaycom/pathway/blob/main/CONTRIBUTING.md)](https://github.com/pathwaycom/pathway/blob/main/CONTRIBUTING.md),
* [x] My code follows the code style of this project,
* [ ] If this is a substantial change, it has prior maintainer approval and the "How this change came about" section is filled in,
* [ ] I described the modification in the CHANGELOG.md file,
* [ ] My change requires a change to the documentation, and I have updated it accordingly.